### PR TITLE
fix(#11): 🐛 Disallow request handling if payload length more than Content-Length value

### DIFF
--- a/src/msgpack_message.rs
+++ b/src/msgpack_message.rs
@@ -91,7 +91,9 @@ impl<T: DeserializeOwned + 'static> Future for MsgPackMessage<T> {
 
 				while let Some(item) = stream.next().await {
 					let chunk = item?;
-					if (body.len() + chunk.len()) > limit {
+					let current_length = body.len() + chunk.len();
+
+					if current_length > length || current_length > limit {
 						return Err(MsgPackError::Overflow);
 					} else {
 						body.extend_from_slice(&chunk);


### PR DESCRIPTION
…tent-Length value